### PR TITLE
Solución al problema del subtotal

### DIFF
--- a/js/cart.js
+++ b/js/cart.js
@@ -149,6 +149,15 @@ function handleLogout(event) {
   
     document.getElementById("subtotal").textContent = totalInPesos.toFixed(2);
   }
+
+  function validateAndUpdateQuantity(input) {
+    let value = parseInt(input.value);
+    if (isNaN(value) || value < 1) {
+      value = 1;
+    }
+    input.value = value;
+    updateQuantity(input.dataset.index, value);
+  }
   
   function updateQuantity(index, newQuantity) {
     const loggedInUser = localStorage.getItem("loggedInUser");


### PR DESCRIPTION
Recuperé la función perdida. Se me quedó atrás en el último cambio de lógica. Esta función es la que toma el dato de la cantidad de un producto desde el input en el carrito y lo guarda. Como faltaba esta función, la única forma de agregar más de una unidad del mismo producto era desde la propia página de detalles del producto (y en ese casó sí se guardaba y se actualizaba el subtotal).